### PR TITLE
Target function to HLS

### DIFF
--- a/ftn/tools/ftn_opt.py
+++ b/ftn/tools/ftn_opt.py
@@ -5,7 +5,7 @@ from xdsl.dialects.builtin import ModuleOp
 
 from ftn.transforms.rewrite_fir_to_core import RewriteFIRToCore
 from ftn.transforms.merge_memref_deref import MergeMemRefDeref
-# from ftn.transforms.extract_target import ExtractTarget
+from ftn.transforms.extract_target import ExtractTarget
 # from ftn.transforms.isolate_target import IsolateTarget
 # from psy.extract_stencil import ExtractStencil
 # from ftn.transforms.tenstorrent.convert_to_tt import ConvertToTT
@@ -26,7 +26,7 @@ class FtnOptMain(xDSLOptMain):
         super().register_all_passes()
         self.register_pass("rewrite-fir-to-core", lambda: RewriteFIRToCore)
         self.register_pass("merge-memref-deref", lambda: MergeMemRefDeref)
-        # self.register_pass("extract-target", lambda: ExtractTarget)
+        self.register_pass("extract-target", lambda: ExtractTarget)
         # self.register_pass("isolate-target", lambda: IsolateTarget)
         # self.register_pass("convert-to-tt", lambda: ConvertToTT)
 

--- a/ftn/tools/ftn_opt.py
+++ b/ftn/tools/ftn_opt.py
@@ -6,6 +6,7 @@ from xdsl.dialects.builtin import ModuleOp
 from ftn.transforms.rewrite_fir_to_core import RewriteFIRToCore
 from ftn.transforms.merge_memref_deref import MergeMemRefDeref
 from ftn.transforms.extract_target import ExtractTarget
+from ftn.transforms.fpga.target_to_hls import TargetToHLSPass
 # from ftn.transforms.isolate_target import IsolateTarget
 # from psy.extract_stencil import ExtractStencil
 # from ftn.transforms.tenstorrent.convert_to_tt import ConvertToTT
@@ -27,6 +28,7 @@ class FtnOptMain(xDSLOptMain):
         self.register_pass("rewrite-fir-to-core", lambda: RewriteFIRToCore)
         self.register_pass("merge-memref-deref", lambda: MergeMemRefDeref)
         self.register_pass("extract-target", lambda: ExtractTarget)
+        self.register_pass("target-to-hls", lambda: TargetToHLSPass)
         # self.register_pass("isolate-target", lambda: IsolateTarget)
         # self.register_pass("convert-to-tt", lambda: ConvertToTT)
 

--- a/ftn/transforms/extract_target.py
+++ b/ftn/transforms/extract_target.py
@@ -39,6 +39,7 @@ class RewriteTarget(RewritePattern):
       arg_types.append(var_op.var_ptr.type)
       arg_ssa.append(var_op.var_ptr)
       locations[var_op]=loc_idx
+      loc_idx+=1
       if isa(var_op.var_ptr.type, builtin.MemRefType):
         memref_type=var_op.var_ptr.type
         src_memref=var_op.var_ptr

--- a/ftn/transforms/extract_target.py
+++ b/ftn/transforms/extract_target.py
@@ -64,8 +64,11 @@ class RewriteTarget(RewritePattern):
         bound_op=var_op.bounds[0].owner
         arg_types.append(bound_op.lower_bound.type)
         arg_ssa.append(bound_op.lower_bound)
+        arg_types.append(bound_op.upper_bound.type)
+        arg_ssa.append(bound_op.upper_bound)
         locations[bound_op]=loc_idx
-        loc_idx+=1
+        # Adding both lower and upper bound
+        loc_idx+=2
       else:
         pass#self.target_ops+=[var_op]
 
@@ -80,7 +83,7 @@ class RewriteTarget(RewritePattern):
         bound_op=var_op.bounds[0].owner
         res_types=[]
         for res in bound_op.results: res_types.append(res.type)
-        new_bounds_op=omp.MapBoundsOp.build(operands=[[new_block.args[locations[bound_op]]], [], [], [], []],
+        new_bounds_op=omp.MapBoundsOp.build(operands=[[new_block.args[locations[bound_op]]], [new_block.args[locations[bound_op]+1]], [], [], []],
                       properties={"stride_in_bytes": bound_op.stride_in_bytes},
                       result_types=res_types)
 

--- a/ftn/transforms/extract_target.py
+++ b/ftn/transforms/extract_target.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass
 import itertools
 from xdsl.utils.hints import isa
 from xdsl.dialects import memref, scf, omp
-from xdsl.ir import Operation, SSAValue, OpResult, Attribute, MLContext, Block, Region
+from xdsl.context import Context
+from xdsl.ir import Operation, SSAValue, OpResult, Attribute, Block, Region
 
 from xdsl.pattern_rewriter import (RewritePattern, PatternRewriter,
                                    op_type_rewrite_pattern,
@@ -31,39 +32,35 @@ class RewriteTarget(RewritePattern):
     # Grab bounds and info, then at end the terminator
     for var in op.map_vars:
       var_op=var.owner
-      var_op.parent.detach_op(var_op)
-      arg_types.append(var_op.var_ptr[0].type)
-      arg_ssa.append(var_op.var_ptr[0])
-      if isa(var_op.var_ptr[0].type, builtin.MemRefType):
-        memref_type=var_op.var_ptr[0].type
-        src_memref=var_op.var_ptr[0]
+      arg_types.append(var_op.var_ptr.type)
+      arg_ssa.append(var_op.var_ptr)
+      locations[var_op]=loc_idx
+      if isa(var_op.var_ptr.type, builtin.MemRefType):
+        memref_type=var_op.var_ptr.type
+        src_memref=var_op.var_ptr
         if isa(memref_type.element_type, builtin.MemRefType):
           assert len(memref_type.shape) == 0
-          memref_type=var_op.var_ptr[0].type.element_type
-          memref_loadop=memref.Load.get(src_memref, [])
+          memref_type=var_op.var_ptr.type.element_type
+          memref_loadop=memref.LoadOp.get(src_memref, [])
           src_memref=memref_loadop.results[0]
           memref_dim_ops.append(memref_loadop)
         for idx, s in enumerate(memref_type.shape):
           assert isa(s, builtin.IntAttr)
           if (s.data == -1):
             # Need to pass the dimension shape size in explicitly as it is deferred
-            const_op=arith.Constant.from_int_and_width(idx, builtin.IndexType())
-            dim_size=memref.Dim.from_source_and_index(src_memref, const_op)
+            const_op=arith.ConstantOp.from_int_and_width(idx, builtin.IndexType())
+            dim_size=memref.DimOp.from_source_and_index(src_memref, const_op)
             memref_dim_ops+=[const_op, dim_size]
             arg_ssa.append(dim_size.results[0])
             arg_types.append(dim_size.results[0].type)
+            loc_idx+=1
 
-      locations[var_op]=loc_idx
-      loc_idx+=1
       if len(var_op.bounds) > 0:
         bound_op=var_op.bounds[0].owner
-        bound_op.parent.detach_op(bound_op)
-        #self.target_ops+=[bound_op, var_op]
-        arg_types.append(bound_op.lower[0].type)
-        arg_ssa.append(bound_op.lower[0])
+        arg_types.append(bound_op.lower_bound.type)
+        arg_ssa.append(bound_op.lower_bound)
         locations[bound_op]=loc_idx
-        # Add two, as second is the size
-        loc_idx+=2
+        loc_idx+=1
       else:
         pass#self.target_ops+=[var_op]
 
@@ -78,7 +75,7 @@ class RewriteTarget(RewritePattern):
         bound_op=var_op.bounds[0].owner
         res_types=[]
         for res in bound_op.results: res_types.append(res.type)
-        new_bounds_op=omp.BoundsOp.build(operands=[[new_block.args[locations[bound_op]]], [], [], [], []],
+        new_bounds_op=omp.MapBoundsOp.build(operands=[[new_block.args[locations[bound_op]]], [], [], [], []],
                       properties={"stride_in_bytes": bound_op.stride_in_bytes},
                       result_types=res_types)
 
@@ -87,8 +84,8 @@ class RewriteTarget(RewritePattern):
 
       res_types=[]
       for res in var_op.results: res_types.append(res.type)
-      mapinfo_op=omp.MapInfoOp.build(operands=[[new_block.args[locations[var_op]]], [], map_bounds],
-                      properties={"map_type": var_op.map_type, "var_name": var_op.var_name, "var_type": var_op.var_type},
+      mapinfo_op=omp.MapInfoOp.build(operands=[new_block.args[locations[var_op]], [], [], map_bounds],
+                      properties={"map_type": var_op.map_type, "name": var_op.var_name, "var_type": var_op.var_type, "map_capture_type": omp.VariableCaptureKindAttr(omp.VariableCaptureKind.BY_REF)},
                       result_types=res_types)
       new_mapinfo_ssa.append(mapinfo_op.results[0])
 
@@ -97,9 +94,9 @@ class RewriteTarget(RewritePattern):
     reg=op.region
     op.detach_region(reg)
 
-    new_omp_target_op=omp.TargetOp.build(operands=[[],[],[], new_mapinfo_ssa], regions=[reg])
+    new_omp_target_op=omp.TargetOp.build(operands=[[],[],[],[],[],[],[],[],[], new_mapinfo_ssa, [], []], regions=[reg])
     new_block.add_op(new_omp_target_op)
-    new_block.add_op(func.Return())
+    new_block.add_op(func.ReturnOp())
 
     new_fn_type=builtin.FunctionType.from_lists(arg_types, [])
 
@@ -110,7 +107,7 @@ class RewriteTarget(RewritePattern):
 
     self.target_ops=[new_func]
 
-    call_fn=func.Call.create(properties={"callee": builtin.SymbolRefAttr("tt_device")}, operands=arg_ssa, result_types=[])
+    call_fn=func.CallOp.create(properties={"callee": builtin.SymbolRefAttr("tt_device")}, operands=arg_ssa, result_types=[])
     op.parent.insert_ops_before(memref_dim_ops+[call_fn], op)
 
     op.parent.detach_op(op)
@@ -122,7 +119,7 @@ class ExtractTarget(ModulePass):
   """
   name = 'extract-target'
 
-  def apply(self, ctx: MLContext, module: builtin.ModuleOp):
+  def apply(self, ctx: Context, module: builtin.ModuleOp):
     rw_target= RewriteTarget()
     walker = PatternRewriteWalker(GreedyRewritePatternApplier([
               rw_target,
@@ -130,7 +127,9 @@ class ExtractTarget(ModulePass):
 
     walker.rewrite_module(module)
 
-    containing_mod=builtin.ModuleOp([])
+    # NOTE: The region recieving the block must be empty. Otherwise, the single block region rule of
+    # the module will not be satisfied.
+    containing_mod=builtin.ModuleOp(Region())
     module.regions[0].move_blocks(containing_mod.regions[0])
 
     new_module=builtin.ModuleOp(rw_target.target_ops, {"target": builtin.StringAttr("tt_device")})

--- a/ftn/transforms/fpga/target_to_hls.py
+++ b/ftn/transforms/fpga/target_to_hls.py
@@ -1,0 +1,137 @@
+from abc import ABC
+from ast import FunctionType, Module
+from hmac import new
+from json import load
+from typing import TypeVar, cast
+from dataclasses import dataclass, field
+import itertools
+from xdsl.utils.hints import isa
+from xdsl.dialects import memref, scf, omp
+from xdsl.context import Context
+from xdsl.ir import Operation, SSAValue, OpResult, Attribute, Block, Region
+
+from xdsl.pattern_rewriter import (RewritePattern, PatternRewriter,
+                                   op_type_rewrite_pattern,
+                                   PatternRewriteWalker,
+                                   GreedyRewritePatternApplier)
+from xdsl.passes import ModulePass
+from xdsl.dialects import builtin, func, llvm, arith
+from ftn.util.visitor import Visitor
+from xdsl.rewriter import InsertPoint
+
+@dataclass
+class TargetFuncToHLS(RewritePattern):
+    def deref_args(self, func_op: func.FuncOp, rewriter : PatternRewriter):
+        """Dereference the arguments of a function operation."""
+        new_input_types = []
+
+        for arg in func_op.body.block.args:
+            if isa(arg.type, builtin.MemRefType):
+                deref_type = arg.type.element_type
+                func_op.replace_argument_type(arg, deref_type, rewriter)
+                new_input_types.append(deref_type)
+
+    def forward_map_info(self, map_info: omp.MapInfoOp, rewriter: PatternRewriter):
+        map_info.omp_ptr.replace_by(map_info.var_ptr)
+
+    def remove_target(self, target_op: omp.TargetOp, target_func: func.FuncOp, rewriter: PatternRewriter):
+        """Remove the target operation from the module."""
+        for operand in target_op.map_vars:
+            operand_idx = target_op.operands.index(operand)
+            block_arg = target_op.region.block.args[operand_idx]
+            block_arg.replace_by(operand)
+
+            if not isinstance(operand.type, builtin.MemRefType):
+                for use in operand.uses:
+                    if isinstance(use.operation, memref.LoadOp):
+                        load_op = use.operation
+                        # NOTE: the operand of the load operation is not a memref anymore, we have dereferenced it, 
+                        # so we forward it.
+                        load_op.res.replace_by(load_op.memref)
+                        rewriter.erase_op(use.operation)
+                    elif isinstance(use.operation, memref.StoreOp):
+                        rewriter.erase_op(use.operation)
+            else:
+                # Adjust the store and load operations that use the dereferenced pointer.
+                for use in operand.uses:
+                    if isinstance(use.operation, memref.LoadOp):
+                        # The first load was used to load the pointer to the array. The index to retrieve an element from the array is applied 
+                        # in the next load. Since we have dereferenced the first pointer, we need to end up with a single load that accesses
+                        # the array directly.
+                        ptr_load_op = use.operation
+
+                        # FIXME: this is assuming each dereferencing load only has one use
+                        for ptr_use in ptr_load_op.res.uses:
+                            if isinstance(ptr_use.operation, memref.LoadOp):
+                                array_load_op = ptr_use.operation
+                                array_idx = array_load_op.indices
+
+                                new_load_op = memref.LoadOp.get(operand, array_idx)
+                                array_load_op.res.replace_by(ptr_load_op.res)
+                                rewriter.replace_op(ptr_load_op, new_load_op)
+                                rewriter.erase_op(array_load_op)
+
+                            elif isinstance(ptr_use.operation, memref.StoreOp):
+                                array_store_op = ptr_use.operation
+                                array_idx = array_store_op.indices
+                                new_store_op = memref.StoreOp.get(array_store_op.value, operand, array_idx)
+                                rewriter.insert_op(new_store_op, InsertPoint.before(ptr_load_op))
+                                rewriter.erase_op(array_store_op)
+                                rewriter.erase_op(ptr_load_op)
+
+
+
+        target_op_terminator = target_op.region.block.last_op
+        assert target_op_terminator
+        rewriter.erase_op(target_op_terminator)
+
+        target_func_terminator = target_func.body.block.last_op
+        assert target_func_terminator
+        for block in reversed(target_op.region.blocks):
+            rewriter.inline_block(block, InsertPoint.before(target_func_terminator))
+
+        rewriter.erase_op(target_op)
+
+    def remove_remaining_omp_ops(self, target_func: func.FuncOp, rewriter: PatternRewriter):
+        """Remove any remaining OpenMP operations in the target function."""
+        for op in target_func.walk():
+            if isinstance(op, omp.MapInfoOp):
+                rewriter.erase_op(op)
+
+        for op in target_func.walk():
+            if isinstance(op, omp.MapBoundsOp):
+                rewriter.erase_op(op)
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, module: builtin.ModuleOp, rewriter: PatternRewriter, /):
+        if "target" not in module.attributes:
+            return
+
+        target_name = module.attributes["target"].data
+        target_func = [op for op in module.walk() if isinstance(op, func.FuncOp) and op.sym_name.data == target_name][0]
+
+        self.deref_args(target_func, rewriter)
+        for map_info in target_func.walk():
+            if not isinstance(map_info, omp.MapInfoOp):
+                continue
+
+            self.forward_map_info(map_info, rewriter)
+
+        target_op = [op for op in target_func.walk() if isinstance(op, omp.TargetOp)][0]
+        self.remove_target(target_op, target_func, rewriter)
+        self.remove_remaining_omp_ops(target_func, rewriter)
+
+
+@dataclass(frozen=True)
+class TargetToHLSPass(ModulePass):
+  """
+  This is the entry point for the transformation pass which will then apply the rewriter
+  """
+  name = 'target-to-hls'
+
+  def apply(self, ctx: Context, module: builtin.ModuleOp):
+    walker = PatternRewriteWalker(GreedyRewritePatternApplier([
+              TargetFuncToHLS(),
+    ]), apply_recursively=False, walk_reverse=True)
+
+    walker.rewrite_module(module)


### PR DESCRIPTION
This pass transforms a target function generated with the `extract-target` pass to an HLS compatible format. This PR includes the changes to the `extract-target` pass to, since this pass depends on it - check #9 for details.

The arguments to the target function are dereferenced, since HLS does not accept pointers to pointers. The operands of the `omp.map.info` operations are forwarded and so are the operands of the `omp.target` operation, so that the operations inside its block can manipulate arrays. The `omp.target`, `omp.bounds` and `omp.map.info` operations are removed. Other operations, such as `omp.parallel` are not treated yet, but will be replaced by the corresponding HLS operation in the `hls` dialect.